### PR TITLE
Restrict instrall-new to slackware64 and patches

### DIFF
--- a/src/slackpkgplus.sh
+++ b/src/slackpkgplus.sh
@@ -1310,17 +1310,16 @@ if [ "$SLACKPKGPLUS" = "on" ];then
             NAME=""
             FULLNAME=""
           fi
-          # When "install-new" is used, there can be same named packages included
-          # in the list from other repositories, only slackware64 and patches should
-          # be used for "install-new" This happens if packages are Addded, then
-          # later Deleted in ChangeLog.txt.
-          if [[ $CMD == install-new ]]; then
-            if [[ ${PKGDATA[0]#*:} != slackware64 ]] && [[ ${PKGDATA[0]#*:} != patches ]]; then
+        fi
+        # When "install-new" is used, there can be same named packages included
+        # in the list from other repositories, only slackware64 and patches should
+        # be used for "install-new" This happens if packages are Addded, then
+        # later Deleted in ChangeLog.txt.
+        if [[ $CMD == install-new ]]; then
+          if [[ ${PKGDATA[0]#*:} != slackware64 ]] && [[ ${PKGDATA[0]#*:} != patches ]]; then
             NAME=""
             FULLNAME=""
           fi
-        fi
-        
         fi
       fi
 

--- a/src/slackpkgplus.sh
+++ b/src/slackpkgplus.sh
@@ -1310,6 +1310,17 @@ if [ "$SLACKPKGPLUS" = "on" ];then
             NAME=""
             FULLNAME=""
           fi
+          # When "install-new" is used, there can be same named packages included
+          # in the list from other repositories, only slackware64 and patches should
+          # be used for "install-new" This happens if packages are Addded, then
+          # later Deleted in ChangeLog.txt.
+          if [[ $CMD == install-new ]]; then
+            if [[ ${PKGDATA[0]#*:} != slackware64 ]] && [[ ${PKGDATA[0]#*:} != patches ]]; then
+            NAME=""
+            FULLNAME=""
+          fi
+        fi
+        
         fi
       fi
 


### PR DESCRIPTION
When "install-new" is used, there can be same named packages included in the list from other repositories, only slackware64 and patches should be used for "install-new" This happens if packages are Addded, then later Deleted in ChangeLog.txt.